### PR TITLE
chore: check commits for valid types

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -3,6 +3,19 @@ name: Lint and Test
 on: [pull_request]
 
 jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit message type
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: "^(feat|fix|docs|style|refactor|test|chore).+"
+          error: "Commit messages must begin with a valid commit type."
+          excludeDescription: "true"
+          excludeTitle: "true"
+          checkAllCommitMessages: "true"
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
   lint-and-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
Updates `lint-and-test` workflow to check commit messages for valid types.
