### PR TITLE
docs: simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,11 @@
-### Description
+## Description
 
 <!-- Add description of work done here -->
 
-### Spec
-
-<!-- Include links to relevant designs and specifications -->
-
-Designs: [Designs](DESIGN_URL)
 Requirements: [Issue/Ticket](LINK_TO_ISSUE)
+Designs: [Designs](DESIGN_URL)
 
-### Validation
-
-<!-- Delete anything irrelevant to this PR -->
-
-- [ ] Visual elements match designs (or look reasonably good if no designs provided)
-- [ ] Linters still pass
-- [ ] Tests still pass
-- [ ] New tests were added or updated, and they pass
-- [ ] Copy was proofread
-- [ ] Documentation was added to clarify anything new or unusual
-- [ ] Changes were browser tested, including functionality, accessibility, responsiveness, and design
-
-#### To Validate
+## To Validate
 
 <!-- Add steps a reviewer should follow to validate your changes -->
 


### PR DESCRIPTION
### Description

<!-- Add description of work done here -->
This removes the "Spec" and "Validation" sections, which are more often than not deleted or not fully relevant to the PR at hand. Moving the links into the description makes sense, and having "To Validate" describe what needs to be tested should be sufficient for most cases.

### To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

Make sure all PR Checks have passed

<!-- Add additional validation steps here -->
