### PR TITLE
fix: ignore chrome extension protocol that breaks tooling

### DIFF
--- a/src/partials/service-worker.js
+++ b/src/partials/service-worker.js
@@ -14,6 +14,9 @@ const PRE_CACHE_URLS = ['/', '/styles.css'];
 // add any hosts that you want to bypass
 const IGNORED_HOSTS = ['localhost'];
 
+// add any protocosl that you want to bypass
+const IGNORED_PROTOCOLS = ['chrome-extension:'];
+
 const addItemsToCache = (cacheName, items = []) => {
   caches.open(cacheName).then((cache) => cache.addAll(items));
 };
@@ -39,10 +42,15 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-  const { hostname } = new URL(event.request.url);
+  const { hostname, protocol } = new URL(event.request.url);
 
   // if it's an ignored host, do nothing
   if (IGNORED_HOSTS.indexOf(hostname) >= 0) {
+    return;
+  }
+
+  // if it's an ignored protocol, do nothing
+  if (IGNORED_PROTOCOLS.indexOf(protocol) >= 0) {
     return;
   }
 


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This fixes an issue with the service worker, where requests from chrome extensions can't be handled correctly, so the extension effectively breaks.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Run the site in a chromium browser with extensions, checking the console to make sure there are no errors about `chrome-extension` URLs 404ing or otherwise failing
<!-- Add additional validation steps here -->
