### PR TITLE
feat: generate sitemap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # set this to "development" in your local env
 # either set this to "production" in CI/prod environments, or leave unset
 NODE_ENV=development
+
+# set this to the domain of the environment it runs on (https://example.com)
+# or localhost for local development
+BASE_URL=http://localhost:8080

--- a/src/pages/_data/processEnv.js
+++ b/src/pages/_data/processEnv.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config();
+
+module.exports = {
+  BASE_URL: process.env.BASE_URL,
+};

--- a/src/pages/service-worker.njk
+++ b/src/pages/service-worker.njk
@@ -1,5 +1,6 @@
 ---
 permalink: '/service-worker.js'
+eleventyExcludeFromCollections: true
 ---
 const VERSION = '{{ global.random() }}';
 {% include "service-worker.js" %}

--- a/src/pages/sitemap.njk
+++ b/src/pages/sitemap.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+    <url>
+      <loc>{{ processEnv.BASE_URL }}{{ page.url | url }}</loc>
+      <lastmod>{{ page.date.toISOString() }}</lastmod>
+    </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This adds a sitemap that includes all the pages included in Eleventy's `collections.all` list. Pages that aren't really pages, like the `service-worker.njk` "page" are excluded from this list.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Visit `/sitemap.xml` and confirm that it is indeed a valid sitemap
<!-- Add additional validation steps here -->
