### PR TITLE
feat: adjust approach for accessibility monitoring

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,13 +1,9 @@
-name: Playwright Tests
+name: End to End Tests
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [pull_request]
 
 jobs:
-  e2e-tests:
+  test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -19,5 +15,5 @@ jobs:
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Run Playwright tests
-        run: npm run test:e2e
+      - name: Run Default Playwright tests
+        run: npm run test:e2e -- --project=Default

--- a/.github/workflows/monitor-accessibility.yml
+++ b/.github/workflows/monitor-accessibility.yml
@@ -1,0 +1,21 @@
+name: Accessibility Checks
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npm run test:e2e -- --project=Accessibility

--- a/e2e-tests/smoke.spec.js
+++ b/e2e-tests/smoke.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
-import pages from '../dist/routes.json';
+
+const pages = ['/', '/about', '/contact', '/404'];
 
 test.describe('automated accessibility checks', () => {
   pages.forEach((route) => {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -41,14 +41,14 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: 'Default',
+      testIgnore: /.*accessibility.spec.js/,
+      retries: 0,
     },
-
-    /* Test against mobile viewports. */
     {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
+      name: 'Accessibility',
+      testMatch: /.*accessibility.spec.js/,
+      retries: 2,
     },
   ],
 
@@ -57,7 +57,7 @@ export default defineConfig({
 
   /* Run a local file server before starting the tests */
   webServer: {
-    command: 'npx serve dist',
-    port: 3000,
+    command: 'npx serve -p 8080 dist',
+    port: 8080,
   },
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 import { config } from 'dotenv';
 
 config();

--- a/src/pages/routes.njk
+++ b/src/pages/routes.njk
@@ -1,0 +1,9 @@
+---
+permalink: /routes.json
+eleventyExcludeFromCollections: true
+---
+[
+  {% for page in collections.all %}
+    "{{ page.url | url }}"{% if not loop.last %},{% endif %}
+  {% endfor %}
+]


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This changes the accessibility checking flow, splitting it into two parts. The "Default" run will run in CI on pull requests against all tests except for those covered by the "Accessibility" run, which will run against all pages on push to main. This will let PR checks be relatively quick, even as the number of pages grows, while still ensuring that accessibility issues get caught.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run test:e2e -- --project=Default"`, making sure that only tests from `smoke.spec.js` run
4. Run `npm run test:e2e -- --project=Accessibility`, making sure that only tests from `accessibility.spec.js` run
5. All tests should pass
<!-- Add additional validation steps here -->
