### PR TITLE
fix: use consistent node version in monitor-accessibility job

### DIFF
--- a/.github/workflows/monitor-accessibility.yml
+++ b/.github/workflows/monitor-accessibility.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
Oops, left one of the jobs using node 18 instead of 16.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
