### PR TITLE
fix: remove font antialiasing from reset

### DIFF
--- a/src/scss/generic/_reset.scss
+++ b/src/scss/generic/_reset.scss
@@ -20,7 +20,6 @@ html {
 
 body {
   line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
 }
 
 img,


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->

This removes antialiasing from the CSS reset, since it's generally not recommended.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
